### PR TITLE
Fix typo: block.super instead of bloc.super

### DIFF
--- a/Module 1/Chapter04/Work_manager/TasksManager/templates/en/public/index.html
+++ b/Module 1/Chapter04/Work_manager/TasksManager/templates/en/public/index.html
@@ -3,7 +3,7 @@
     Hello World Title
 {% endblock %}
 {% block h1 %}
-    {{ bloc.super }}Hello World Django
+    {{ block.super }}Hello World Django
 {% endblock %}
 {% block article_content %}
     Hello world !


### PR DESCRIPTION
I was reading the book at Chapter 4, section `Extending the templates`, and came across the line using `bloc.super`, which looked like a type.

I came over to the github repository to double check and found that the code here also used `bloc.super`.

It seems like `block.super` is the correct usage, as per the documentation of django: https://docs.djangoproject.com/es/1.10/ref/templates/language/
